### PR TITLE
Resized logo in My Schedule button

### DIFF
--- a/iOSDevUK/Storyboards/MainStoryboard.storyboard
+++ b/iOSDevUK/Storyboards/MainStoryboard.storyboard
@@ -109,21 +109,24 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="140" height="140"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <subviews>
-                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MySchedule-8" translatesAutoresizingMaskIntoConstraints="NO" id="tJ4-Nj-sGF">
-                                                                <rect key="frame" x="0.0" y="0.0" width="140" height="140"/>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MySchedule-8" translatesAutoresizingMaskIntoConstraints="NO" id="tJ4-Nj-sGF">
+                                                                <rect key="frame" x="0.0" y="0.0" width="140" height="114.5"/>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Schedule" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5hg-hg-7Eu">
                                                                 <rect key="frame" x="4" y="119.5" width="128" height="20.5"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="20" id="yuz-7Z-Hrc"/>
+                                                                </constraints>
                                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="17"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
                                                     </view>
-                                                    <color key="backgroundColor" red="0.45785968587461701" green="0.66155893409457378" blue="0.92086373730964466" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" red="0.14509803921568629" green="0.33333333333333331" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="bottom" secondItem="tJ4-Nj-sGF" secondAttribute="bottom" id="7K9-zw-Ila"/>
                                                         <constraint firstItem="tJ4-Nj-sGF" firstAttribute="leading" secondItem="fcl-7h-TcA" secondAttribute="leading" id="7ig-WH-Z96"/>
+                                                        <constraint firstItem="5hg-hg-7Eu" firstAttribute="top" secondItem="tJ4-Nj-sGF" secondAttribute="bottom" constant="5" id="DMK-E2-8oN"/>
                                                         <constraint firstAttribute="trailing" secondItem="tJ4-Nj-sGF" secondAttribute="trailing" id="De1-aE-U32"/>
                                                         <constraint firstAttribute="trailing" secondItem="5hg-hg-7Eu" secondAttribute="trailing" constant="8" id="FkX-vQ-WWd"/>
                                                         <constraint firstAttribute="bottom" secondItem="5hg-hg-7Eu" secondAttribute="bottom" id="LSh-PK-L06"/>
@@ -827,7 +830,7 @@ Information</string>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WXu-NW-mxO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-11510" y="-1146"/>
+            <point key="canvasLocation" x="-11511.200000000001" y="-1146.4767616191905"/>
         </scene>
         <!--Attendee Info Table View Controller-->
         <scene sceneID="tbQ-ON-hrg">


### PR DESCRIPTION
Previously the button label and logo were overlapping making the label text hard to read.

Before:
<img width="148" alt="screen shot 2018-09-05 at 11 44 22" src="https://user-images.githubusercontent.com/1109819/45088510-1928fb80-b101-11e8-8684-530cb7424d4a.png">

After:
<img width="152" alt="screen shot 2018-09-05 at 11 43 48" src="https://user-images.githubusercontent.com/1109819/45088516-1f1edc80-b101-11e8-9eb7-4a2d7b98f869.png">
