### PR TITLE
Auto-scroll to the current/next session in Programme

### DIFF
--- a/iOSDevUK/Controllers/Sessions/ProgrammeTableViewController.swift
+++ b/iOSDevUK/Controllers/Sessions/ProgrammeTableViewController.swift
@@ -100,33 +100,22 @@ class ProgrammeTableViewController: UIViewController, UITableViewDelegate, UITab
     
     /// Find the current or next session for the current set of sessions and scroll to it.
     func scrollToCurrentSession(animated: Bool) {
-        guard let fetchedResultsController = fetchedResultsController,
-                let sections = fetchedResultsController.sections else {
+        guard let fetchedResultsController = fetchedResultsController else {
             return
         }
         
         /// Find the session in the already-fetched results
-        let now = Date()
         let nextOrCurrentSession = fetchedResultsController.fetchedObjects?.first { session in
-            guard let startTimeNSDate = session.startTime,
-                    let endTimeNSDate = session.endTime else {
+            guard let endTime = session.endTime else {
                 return false
             }
-            let startTime = startTimeNSDate as Date
-            let endTime = endTimeNSDate as Date
-            return (startTime <= now && endTime >= now) || (startTime >= now)
+            return endTime.timeIntervalSinceNow > 0
         }
         
         /// If we found one, resolve it to a section index and row
         if let sessionToScrollTo = nextOrCurrentSession {
-            for (sectionIndex, section) in sections.enumerated() {
-                if let rowIndex = section.objects?.firstIndex(where: {
-                    let session = $0 as! Session
-                    return session == sessionToScrollTo
-                }) {
-                    tableView.scrollToRow(at: IndexPath(row: rowIndex, section: sectionIndex), at: .top, animated: animated)
-                    break
-                }
+            if let indexPathOfSessionToScrollTo = fetchedResultsController.indexPath(forObject: sessionToScrollTo) {
+                tableView.scrollToRow(at: indexPathOfSessionToScrollTo, at: .top, animated: animated)
             }
         }
         


### PR DESCRIPTION
This was something I kept wishing the app would do, so I made it.

It's probably hacky/not the way you would do it knowing the code better but it seems reasonable to me e.g. a new CoreData query for this rather than scanning the fetched objects seems overkill given we already have the sessions loaded.

Challenge: try to find a way to scroll to the current session *without* animating the scroll when the VC first loads. I can't find a time when the tableview has fully laid out for the auto-sizing cells and the wrapping text. Everything I tried meant it scrolled to the wrong location (more noticeable later in the day and the longer the session item names are) - because on first display it still thinks the layout is the estimated size. Help?
